### PR TITLE
Rename basic Arch install script

### DIFF
--- a/.config/setup/1-archinstall-basics.sh
+++ b/.config/setup/1-archinstall-basics.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# 1-archinstall-basics.sh - set console font and enable NTP
+
+set -euo pipefail
+
+setfont ter-120n
+timedatectl set-ntp true


### PR DESCRIPTION
## Summary
- rename `01-setfont-ntp.sh` to `1-archinstall-basics.sh`

## Testing
- `bash -n .config/setup/1-archinstall-basics.sh`


------
https://chatgpt.com/codex/tasks/task_e_683efb97e30c832999deff1fa4ed3273