### PR TITLE
Add encryption script for arch install

### DIFF
--- a/.config/setup/3-archinstall-encrypt.sh
+++ b/.config/setup/3-archinstall-encrypt.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 3-archinstall-encrypt.sh - encrypt root partition and open it
+set -euo pipefail
+
+while true; do
+    read -rsp "Enter passphrase for /dev/sda2: " passphrase
+    echo
+    read -rsp "Confirm passphrase: " passphrase_confirm
+    echo
+
+    if [[ "$passphrase" == "$passphrase_confirm" ]]; then
+        break
+    fi
+
+    echo "Passphrases do not match. Please try again." >&2
+done
+
+echo "Formatting /dev/sda2..." >&2
+printf '%s' "$passphrase" | \
+    cryptsetup luksFormat --pbkdf pbkdf2 --label ROOTFS --key-file - /dev/sda2
+
+echo "Opening encrypted partition as cryptroot." >&2
+printf '%s' "$passphrase" | cryptsetup open --key-file - /dev/sda2 cryptroot
+
+unset passphrase passphrase_confirm


### PR DESCRIPTION
## Summary
- add 3-archinstall-encrypt.sh script for setting up encrypted root
- improve passphrase handling with retry loop

## Testing
- `bash -n .config/setup/3-archinstall-encrypt.sh`
- `shellcheck .config/setup/3-archinstall-encrypt.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f0e724c5883299dd27f21b745db72