### PR TITLE
Add encryption script for arch install

### DIFF
--- a/.config/setup/3-archinstall-encrypt.sh
+++ b/.config/setup/3-archinstall-encrypt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# 3-archinstall-encrypt.sh - encrypt root partition and open it
+set -euo pipefail
+
+# Automatically confirm formatting while still prompting for the passphrase.
+printf 'YES\n' | cryptsetup luksFormat --pbkdf pbkdf2 --label ROOTFS --key-file /dev/tty /dev/sda2
+cryptsetup open /dev/sda2 cryptroot

--- a/.config/setup/3-archinstall-encrypt.sh
+++ b/.config/setup/3-archinstall-encrypt.sh
@@ -2,6 +2,6 @@
 # 3-archinstall-encrypt.sh - encrypt root partition and open it
 set -euo pipefail
 
-# Automatically confirm formatting while still prompting for the passphrase.
-printf 'YES\n' | cryptsetup luksFormat --pbkdf pbkdf2 --label ROOTFS --key-file /dev/tty /dev/sda2
+# Automatically confirm formatting and let cryptsetup prompt for the passphrase
+printf 'YES\n' | cryptsetup luksFormat --pbkdf pbkdf2 --label ROOTFS /dev/sda2
 cryptsetup open /dev/sda2 cryptroot


### PR DESCRIPTION
## Summary
- add 3-archinstall-encrypt.sh script for setting up encrypted root
- ensure cryptsetup prompts for passphrase while confirming formatting

## Testing
- `bash -n .config/setup/3-archinstall-encrypt.sh`
- ❌ `shellcheck .config/setup/3-archinstall-encrypt.sh` *(command not found)*


------
https://chatgpt.com/codex/tasks/task_e_683f0e724c5883299dd27f21b745db72