### PR TITLE
Add encryption script for arch install

### DIFF
--- a/.config/setup/3-archinstall-encrypt.sh
+++ b/.config/setup/3-archinstall-encrypt.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# 3-archinstall-encrypt.sh - encrypt root partition and open it
+set -euo pipefail
+
+while true; do
+    read -rsp "Enter passphrase for /dev/sda2: " passphrase
+    echo
+    read -rsp "Confirm passphrase: " passphrase_confirm
+    echo
+    if [[ "$passphrase" == "$passphrase_confirm" ]]; then
+        break
+    else
+        echo "Passphrases do not match. Please try again." >&2
+    fi
+done
+
+echo "Formatting /dev/sda2..." >&2
+printf '%s' "$passphrase" | \
+    cryptsetup luksFormat --batch-mode --pbkdf pbkdf2 --label ROOTFS --key-file - /dev/sda2
+
+echo "Opening encrypted partition as cryptroot." >&2
+printf '%s' "$passphrase" | cryptsetup open --key-file - /dev/sda2 cryptroot
+


### PR DESCRIPTION
## Summary
- add 3-archinstall-encrypt.sh script for setting up encrypted root
- prompt user for passphrase and confirm until they match

## Testing
- `bash -n .config/setup/3-archinstall-encrypt.sh`
- ❌ `shellcheck .config/setup/3-archinstall-encrypt.sh` (command not found)

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683f0e724c5883299dd27f21b745db72